### PR TITLE
OSX UNIX获取filepath错误

### DIFF
--- a/bboss-util/src-rt/org/frameworkset/runtime/CommonLauncher.java
+++ b/bboss-util/src-rt/org/frameworkset/runtime/CommonLauncher.java
@@ -299,7 +299,8 @@ public class CommonLauncher
             try
             {
                 File path = null;//new File(URLDecoder.decode(location.toExternalForm().substring(6), "UTF-8")).getParentFile();
-                if(!CommonLauncher.isLinux())
+                if(!CommonLauncher.isLinux()
+                	&& !CommonLauncher.isOSX())
                 {
                 	path = new File(URLDecoder.decode(location.toExternalForm().substring(6), "UTF-8")).getParentFile();
                 }


### PR DESCRIPTION
computeApplicationDir方法增加一个逻辑判断  && !CommonLauncher.isOSX()